### PR TITLE
Added Kubernetes cluster initalization .yaml files for a simple cluster - including parametrized config.json

### DIFF
--- a/kube/elasticsearch.yaml
+++ b/kube/elasticsearch.yaml
@@ -1,0 +1,11 @@
+apiVersion: elasticsearch.k8s.elastic.co/v1
+kind: Elasticsearch
+metadata:
+  name: es
+spec:
+    version: 8.17.2
+    nodeSets:
+    - name: default
+      count: 1
+      config:
+        node.store.allow_mmap: false

--- a/kube/kibana.yaml
+++ b/kube/kibana.yaml
@@ -1,0 +1,9 @@
+apiVersion: kibana.k8s.elastic.co/v1
+kind: Kibana
+metadata:
+  name: log-aggregator-kibana
+spec:
+  version: 8.17.2
+  count: 1
+  elasticsearchRef:
+    name: quickstart

--- a/kube/log-aggregator-volume.yaml
+++ b/kube/log-aggregator-volume.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: log-aggregator-config
+  labels:
+    app: aggregator
+data:
+  config.json : "insert your config.json content here"
+  

--- a/kube/log-aggregator.yaml
+++ b/kube/log-aggregator.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: log-aggregator
+  namespace: default
+  labels: 
+    app: log-aggregator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: log-aggregator
+  template:
+    metadata:
+      labels:
+        app: log-aggregator
+    spec:
+      containers:
+      - name: log-aggregator-container
+        image: simasgrilo/log-aggregator:latest
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+          - name:  config-volume
+            mountPath: '/app/'
+            subPath: config.json
+            readOnly: true
+        ports:
+        - containerPort: 8081
+        resources:
+          limits:
+            memory: 512Mi
+            cpu: "1"
+          requests:
+            memory: 256Mi
+            cpu: "0.2"
+      volumes:
+        - name: config-volume
+          configMap:  
+            name: log-aggregator-config #name of the config map create also in kubectl.
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name:  log-aggregator-service
+spec:
+  selector:
+    app:  log-aggregator
+  type: NodePort
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort:  8081


### PR DESCRIPTION
# Tl;dr
Development of startup files for a kubernetes cluster containing respectively an instance for elasticsearch, kubernetes and a log-aggregator. 

# Context
This change enables the versioning of files used to create a Kubernetes cluster with log-aggregator, elasticsearch and kubernetes.

# Test Plan
TBD

# Links
N/A

# Checklist 
- [X] Pull request title is succinct with [tiny] if it’s extra small
- [X] Describes the problem
- [X] Describes the solution (screenshots included if UI changes)
- [ ] Has a test plan
- [ ] Contains links to any context (Slack, Figma, JIRA ticket, etc.)
- [X] Code is self reviewed for readability, approach, and edge cases
- [ ] Lines changed that may require additional explanation are annotated with an explanation
- [ ] Change is ideally < 500 lines if possible. < 150 is ideal.