### PR TITLE
Fix: name of mount path within log-aggregator.yaml to point to the correct file path in the volume mount (Issue #1)

### DIFF
--- a/kube/kibana.yaml
+++ b/kube/kibana.yaml
@@ -6,4 +6,4 @@ spec:
   version: 8.17.2
   count: 1
   elasticsearchRef:
-    name: quickstart
+    name: es

--- a/kube/log-aggregator.yaml
+++ b/kube/log-aggregator.yaml
@@ -21,7 +21,7 @@ spec:
         imagePullPolicy: IfNotPresent
         volumeMounts:
           - name:  config-volume
-            mountPath: '/app/'
+            mountPath: '/app/config.json'
             subPath: config.json
             readOnly: true
         ports:


### PR DESCRIPTION
# Context
Fix of a wrong path setup in file log-aggregator.yaml which led to kubernetes's mountVolume to wipe out the contents of container directory /app. To fix, one needs to set the following:

```
          - name:  config-volume
            mountPath: '/app/config.json'
            subPath: config.json
````

where ```mountPath``` matches the same directory the app expects to find file config.json as a well-formed JSON to be read. subPath copies only the content of config.json from the configMap to /app as a config.json file.


# Test Plan
Deploy manually log-aggregator.yaml and see that the container starts up properly, with no errors in either the mount volume or GUnicorn not finding LogAggregator module.


# Checklist 
- [X] Pull request title is succinct with [tiny] if it’s extra small
- [X] Describes the problem
- [X] Describes the solution (screenshots included if UI changes)
- [ ] Has a test plan
- [ ] Contains links to any context (Slack, Figma, JIRA ticket, etc.)
- [X] Code is self reviewed for readability, approach, and edge cases
- [X] Lines changed that may require additional explanation are annotated with an explanation
- [ ] Change is ideally < 500 lines if possible. < 150 is ideal.